### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/crossref/doi.py
+++ b/crossref/doi.py
@@ -98,9 +98,9 @@ def clean_doi(doi,_format='value'):
     elif _format == 'doi':
         return 'doi:' + value
     elif _format == 'http':
-        return 'http://dx.doi.org/' + value
+        return 'https://doi.org/' + value
     elif _format == 'http':
-        return 'http://dx.doi.org/' + value    
+        return 'https://doi.org/' + value    
     else:
         raise Exception('Unhandled format for DOI cleaning')
 

--- a/crossref/doi.py
+++ b/crossref/doi.py
@@ -81,8 +81,6 @@ def clean_doi(doi,_format='value'):
     if doi.startswith('10.'):
         #TODO: do other registries exist? 100.?
         value = doi
-    elif doi.startswith('https://doi.org/'):
-        return doi
     else:
         lower_doi = doi.lower()
         if lower_doi.startswith('doi:'):
@@ -94,6 +92,8 @@ def clean_doi(doi,_format='value'):
             value = doi[19:]
         elif lower_doi.startswith('http://doi.org/'):
             value = doi[15:]
+        elif lower_doi.startswith('httpw://doi.org/'):
+            value = doi[16:]
         else:
             raise Exception('Form of DOI is unrecognized, value = %s' % doi)
         
@@ -102,7 +102,7 @@ def clean_doi(doi,_format='value'):
     elif _format == 'doi':
         return 'doi:' + value
     elif _format == 'http':
-        return 'https://doi.org/' + value
+        return 'http://doi.org/' + value
     elif _format == 'https':
         return 'https://doi.org/' + value    
     else:

--- a/crossref/doi.py
+++ b/crossref/doi.py
@@ -81,6 +81,8 @@ def clean_doi(doi,_format='value'):
     if doi.startswith('10.'):
         #TODO: do other registries exist? 100.?
         value = doi
+    elif doi.startswith('https://doi.org/'):
+        return doi
     else:
         lower_doi = doi.lower()
         if lower_doi.startswith('doi:'):
@@ -90,6 +92,8 @@ def clean_doi(doi,_format='value'):
             value = doi[18:]
         elif lower_doi.startswith('https://dx.doi.org/'):
             value = doi[19:]
+        elif lower_doi.startswith('http://doi.org/'):
+            value = doi[15:]
         else:
             raise Exception('Form of DOI is unrecognized, value = %s' % doi)
         

--- a/crossref/doi.py
+++ b/crossref/doi.py
@@ -92,7 +92,7 @@ def clean_doi(doi,_format='value'):
             value = doi[19:]
         elif lower_doi.startswith('http://doi.org/'):
             value = doi[15:]
-        elif lower_doi.startswith('httpw://doi.org/'):
+        elif lower_doi.startswith('https://doi.org/'):
             value = doi[16:]
         else:
             raise Exception('Form of DOI is unrecognized, value = %s' % doi)

--- a/crossref/doi.py
+++ b/crossref/doi.py
@@ -99,7 +99,7 @@ def clean_doi(doi,_format='value'):
         return 'doi:' + value
     elif _format == 'http':
         return 'https://doi.org/' + value
-    elif _format == 'http':
+    elif _format == 'https':
         return 'https://doi.org/' + value    
     else:
         raise Exception('Unhandled format for DOI cleaning')


### PR DESCRIPTION
Hello and thanks for working on this awesome tools collection :-)

May I suggest to point DOI links to the [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers!

PS: It looks like a code duplication, but I assume that's my novice-ness to python. Please let me know if it is, and I'll append a de-duplicating commit.

PPS: Also, shall I open similar PRs to the [other tools](https://github.com/search?q=org%3AScholarTools+dx&type=Code)?